### PR TITLE
Use $content.encode to fix eg/dump-env.psgi6

### DIFF
--- a/eg/dump-env.psgi6
+++ b/eg/dump-env.psgi6
@@ -5,6 +5,6 @@ sub app(%env) {
     for %env.kv -> $key, $value {
         push @lines, "$key => $value"
     }
-    my $content = @lines.join("\n");
+    my $content = @lines.join("\n").encode;
     return 200, ['content-length' => $content.bytes], [$content];
 }


### PR DESCRIPTION
`$content` is a string, and needs to be encoded (to `utf8`) first before getting content-length via `.bytes`.