### PR TITLE
Make sure to sort mappings before starting to match

### DIFF
--- a/t/Crust-App/urlmap.t
+++ b/t/Crust-App/urlmap.t
@@ -26,17 +26,15 @@ my $client = -> $cb {
     is $res.code, 200;
     is $res.content.decode, "world";
 
-    # TODO
-    #$req = HTTP::Request.new(GET => "http://localhost:5000/hello");
-    #$res = $cb($req);
-    #is $res.code, 200;
-    #is $res.content.decode, "こんにちわ";
+    $req = HTTP::Request.new(GET => "http://localhost:5000/hello");
+    $res = $cb($req);
+    is $res.code, 200;
+    is $res.content.decode, "こんにちわ";
 
-    # TODO
-    #$req = HTTP::Request.new(GET => "http://127.0.0.1:5000/world");
-    #$res = $cb($req);
-    #is $res.code, 200;
-    #is $res.content.decode, "世界";
+    $req = HTTP::Request.new(GET => "http://127.0.0.1:5000/world");
+    $res = $cb($req);
+    is $res.code, 200;
+    is $res.content.decode, "世界";
 
     $req = HTTP::Request.new(GET => "/zoo");
     $res = $cb($req);


### PR DESCRIPTION
URLMap.pm6 was not sorting $!mapping at all, so when you had

   mount "/", -> %env {...};
   mount "/foo", -> %env {...};

You had problems - specifically, because "/" (i.e. map<loc> == "")
has special semantics, and must be evaluated at the very end.

See code around here:
https://github.com/plack/Plack/blob/eba6ba8a54802a4bca5443944d903f49d81a3938/lib/Plack/App/URLMap.pm#L32-L36
https://github.com/plack/Plack/blob/eba6ba8a54802a4bca5443944d903f49d81a3938/lib/Plack/App/URLMap.pm#L59

This change fixes the above problem, and also reinstates the
TODO tests that were commented out in t/Crust-App/urlmap.t

Also, note that this used to be done in prepare_app() phase in
Plack. It might be better to add something like this so we can
run initialization that happens only once