### PR TITLE
Fix 'magical trash' cookies bug

### DIFF
--- a/lib/Crust/Request.pm6
+++ b/lib/Crust/Request.pm6
@@ -243,6 +243,7 @@ method cookies() {
     my $parsed = crush-cookie($!env<HTTP_COOKIE>);
     $!env<crust.cookie.parsed> = $parsed;
     $!env<crust.cookie.string> = $!env<HTTP_COOKIE>;
+    return $parsed;
 }
 
 =begin pod

--- a/t/crust/request.t
+++ b/t/crust/request.t
@@ -71,7 +71,6 @@ subtest {
     my $req = Crust::Request.new({
         :HTTP_COOKIE<hoge=fuga>
     });
-    $req.cookies.perl; # magical trash. if you remove this, this test fails.
     my $cookies = $req.cookies;
     my $hoge = $cookies<hoge>;
     is $hoge, 'fuga';


### PR DESCRIPTION
We were returning the raw cookie string the first time .cookies was called.