### PR TITLE
Fix test about hash comparison

### DIFF
--- a/t/crust/utils.t
+++ b/t/crust/utils.t
@@ -13,10 +13,10 @@ subtest  {
 subtest {
     my ($head, %opts) = parse-header-item('form-data; name="upload"; filename="hello.pl"');
     is $head, 'form-data';
-    is %opts, (
+    is-deeply %opts, {
         name => 'upload',
         filename => 'hello.pl',
-    );
+    };
 }, 'parse-header-item';
 
 subtest {


### PR DESCRIPTION
We should use `is-deeply` for hash comparison instead of `is`.
(This test is failed with latest Perl6(Moar) because Hash.Str is changed. )

```
# Failed test at t/crust/utils.t line 16
    # expected: 'name	upload filename	hello.pl'
    #      got: 'filename	hello.pl
# name	upload'
    # Looks like you failed 1 test of 2
```