### PR TITLE
Fix removed @*INC

### DIFF
--- a/lib/Crust/Runner.pm6
+++ b/lib/Crust/Runner.pm6
@@ -72,7 +72,8 @@ method parse-options(@args) {
 }
 
 method !setup() {
-    @*INC.prepend: @!inc;
+    my @inc = @!inc;
+    EVAL qq{use lib @inc};
     for @!modules {
         require ::($_)
     }


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.