### PR TITLE
Don't use return in Block

### DIFF
--- a/t/Crust-Middleware/auth_basic.t
+++ b/t/Crust-Middleware/auth_basic.t
@@ -10,7 +10,7 @@ my %map = (
 my $app = builder {
     enable "Auth::Basic",
         :authenticator(-> $u, $p, %env {
-            return %map{$u} && %map{$u} eq $p;
+            %map{$u} && %map{$u} eq $p;
         });
     -> %env { 200, [:Content-Type('text/plain')], ["Hello {%env<REMOTE_USER>}!"] }
 };

--- a/t/Crust-Middleware/static.t
+++ b/t/Crust-Middleware/static.t
@@ -23,7 +23,7 @@ my $app = builder {
         root => ".",
         content-type => sub ($file) { "text/x-fooo" };
     -> %env {
-        return (200, [ 'Content-Type' => 'text/plain' ], [ 'Hello World' ]);
+        (200, [ 'Content-Type' => 'text/plain' ], [ 'Hello World' ]);
     };
 };
 


### PR DESCRIPTION
Because it returns from outside of Routine.

This patch fixes following test errors.

```
% prove -v -e 'perl6 -Ilib' t/Crust-Middleware/auth_basic.t t/Crust-Middleware/static.t
t/Crust-Middleware/auth_basic.t ..
ok 1 -
not ok 2 - Should succeed

# Failed test 'Should succeed'
# at t/Crust-Middleware/auth_basic.t line 32
# expected: '200'
#      got: '500'
not ok 3 -

# Failed test at t/Crust-Middleware/auth_basic.t line 33
# expected: 'Hello admin!'
#      got: 'Attempt to return outside of any Routine'
not ok 4 - Should succeed

# Failed test 'Should succeed'
# at t/Crust-Middleware/auth_basic.t line 39
# expected: '200'
#      got: '500'
not ok 5 -

# Failed test at t/Crust-Middleware/auth_basic.t line 40
# expected: 'Hello john!'
#      got: 'Attempt to return outside of any Routine'
ok 6 - Should fail
1..6
# Looks like you failed 4 tests of 6
Dubious, test returned 4 (wstat 1024, 0x400)
Failed 4/6 subtests
t/Crust-Middleware/static.t ......
not ok 1 -

# Failed test at t/Crust-Middleware/static.t line 36
# expected: '200'
#      got: '500'
not ok 2 -

# Failed test at t/Crust-Middleware/static.t line 37
# expected: 'Hello World'
#      got: 'Attempt to return outside of any Routine'
ok 3 -
ok 4 -
ok 5 -
ok 6 -
ok 7 -
1..7
# Looks like you failed 2 tests of 7
Dubious, test returned 2 (wstat 512, 0x200)
Failed 2/7 subtests

Test Summary Report
-------------------
t/Crust-Middleware/auth_basic.t (Wstat: 1024 Tests: 6 Failed: 4)
  Failed tests:  2-5
  Non-zero exit status: 4
t/Crust-Middleware/static.t    (Wstat: 512 Tests: 7 Failed: 2)
  Failed tests:  1-2
  Non-zero exit status: 2
Files=2, Tests=13, 48 wallclock secs ( 0.08 usr  0.01 sys + 45.47 cusr  2.91 csys = 48.47 CPU)
Result: FAIL
```