### PR TITLE
Support the latest API of IO::Blob

### DIFF
--- a/t/Crust-Builder/basic.t
+++ b/t/Crust-Builder/basic.t
@@ -29,7 +29,7 @@ subtest {
     );
 
     my @res = $app(%env);
-    $io.seek(0, 0);
+    $io.seek(0, SeekFromBeginning);
     my $s = $io.slurp-rest(:enc<ascii>);
 
     ok $s.starts-with('127.0.0.1 - - ['), "starts with 127.0.0.1";
@@ -65,7 +65,7 @@ subtest {
         );
 
         my @res = $app(%env);
-        $io.seek(0, 0);
+        $io.seek(0, SeekFromBeginning);
         my $s = $io.slurp-rest(:enc<ascii>);
 
         ok $s.starts-with('127.0.0.1 - - ['), "starts with 127.0.0.1";
@@ -100,7 +100,7 @@ subtest {
         );
 
         my @res = $app(%env);
-        $io.seek(0, 0);
+        $io.seek(0, SeekFromBeginning);
         my $s = $io.slurp-rest(:enc<ascii>);
 
         is $s, '', 'empty logging';

--- a/t/Crust-Builder/mount.t
+++ b/t/Crust-Builder/mount.t
@@ -2,7 +2,6 @@ use v6;
 use Test;
 use Crust::Builder;
 use Crust::Test;
-use IO::Blob;
 
 subtest {
     my $app = sub ($env) {

--- a/t/Crust-Middleware/accesslog.t
+++ b/t/Crust-Middleware/accesslog.t
@@ -10,7 +10,7 @@ my &hello-app = sub (%env) {
 
 sub make-check-combined-logs($io) {
     return sub {
-        $io.seek(0,0); # rewind
+        $io.seek(0, SeekFromBeginning); # rewind
         my $s = $io.slurp-rest(:enc<ascii>);
         if ! ok($s.defined, "\$s is defined") {
             note $s;

--- a/t/Crust-Middleware/stack-trace.t
+++ b/t/Crust-Middleware/stack-trace.t
@@ -36,7 +36,7 @@ subtest {
     like %env<crust.stacktrace.text>, rx{'in block <unit> at t/Crust-Middleware/stack-trace.t:16'};
     like %env<crust.stacktrace.html>, rx{'Error:' \s+ 'in block &lt;unit&gt; at t/Crust-Middleware/stack-trace.t:16'};
 
-    $io.seek(0, 0); # rewind
+    $io.seek(0, SeekFromBeginning); # rewind
     like $io.slurp-rest, rx{'in block <unit> at t/Crust-Middleware/stack-trace.t:16'};
 }, 'Errors with plain text trace';
 
@@ -64,7 +64,7 @@ subtest {
     like %env<crust.stacktrace.text>, rx{'in block <unit> at t/Crust-Middleware/stack-trace.t:43'};
     like %env<crust.stacktrace.html>, rx{'Error:' \s+ 'in block &lt;unit&gt; at t/Crust-Middleware/stack-trace.t:43'};
 
-    $io.seek(0, 0); # rewind
+    $io.seek(0, SeekFromBeginning); # rewind
     like $io.slurp-rest, rx{'in block <unit> at t/Crust-Middleware/stack-trace.t:43'};
 }, 'Errors with html trace';
 
@@ -83,7 +83,7 @@ subtest {
     my $ret = $code(%env);
     is $ret[0], 500;
 
-    $io.seek(0, 0); # rewind
+    $io.seek(0, SeekFromBeginning); # rewind
     is $io.slurp-rest, '';
 }, 'Test for no-print-errors';
 


### PR DESCRIPTION
Use `seek(IO::Blob:D: int $offset, SeekType:D $whence)`
instead `seek(IO::Blob:D: int $offset, int $whence)`.

ref: https://github.com/moznion/p6-IO-Blob/pull/6