### PR TITLE
Repace EVAL qq{use lib} by proper API call

### DIFF
--- a/lib/Crust/Runner.pm6
+++ b/lib/Crust/Runner.pm6
@@ -73,8 +73,8 @@ method parse-options(@args) {
 }
 
 method !setup() {
-    my @inc = @!inc;
-    EVAL qq{use lib @inc};
+    CompUnit::RepositoryRegistry.use-repository(CompUnit::RepositoryRegistry.repository-for-spec($_))
+        for @!inc;
     for @!modules {
         require ::($_)
     }


### PR DESCRIPTION
The replacement is exactly what a "use lib" compiles to without the
security issues that EVAL could bring.