### PR TITLE
make FastCGI::NativeCall optional

### DIFF
--- a/lib/Crust/Handler/FastCGI.pm6
+++ b/lib/Crust/Handler/FastCGI.pm6
@@ -2,8 +2,8 @@ use v6;
 
 unit class Crust::Handler::FastCGI;
 
-use FastCGI::NativeCall;
-use FastCGI::NativeCall::PSGI;
+require FastCGI::NativeCall;
+require FastCGI::NativeCall::PSGI;
 
 has $!psgi;
 
@@ -14,8 +14,8 @@ method new(*%args) {
 }
 
 method !initialize(:$socket, :$backlog) {
-    my $sock = FastCGI::NativeCall::OpenSocket($socket, $backlog);
-    $!psgi = FastCGI::NativeCall::PSGI.new(FastCGI::NativeCall.new($sock));
+    my $sock = &::("FastCGI::NativeCall::OpenSocket")($socket, $backlog);
+    $!psgi = ::("FastCGI::NativeCall::PSGI").new(::("FastCGI::NativeCall").new($sock));
     self;
 }
 


### PR DESCRIPTION
It seems that if we want a module Foo to be an optional requirement, we cannot use `use Foo`.

This PR replaces `use FastCGI::NativeCall` with `require FastCGI::NativeCall`, which makes FastCGI::NativeCall optional.

