### PR TITLE
[nit] fix test message

### DIFF
--- a/t/Crust-Middleware/lint.t
+++ b/t/Crust-Middleware/lint.t
@@ -19,7 +19,7 @@ subtest {
         }
     );
 
-    lives-ok({$code(%env)}), 'Should work fine';
+    lives-ok({$code(%env)}, 'Should work fine');
 
     subtest {
         temp %env = %env;


### PR DESCRIPTION
Current test code cannot pass the message argument to `lives-ok` at t/Crust-Middleware/lint.t, and it prints WARNING.
```
WARNINGS for /MYDIRECTORY/.panda-work/1481903333_29/t/Crust-Middleware/lint.t:
Useless use of constant string "Should work fine" in sink context (lines 22, 22)
t/Crust-Middleware/lint.t ............. ok
```
With this patch (and add `-v` to prove), I can see `Should work fine` is passed to `lives-ok`.
```
t/Crust-Middleware/lint.t .............
    ok 1 - Should work fine
        ok 1 -
        1..1
...
```
