### PR TITLE
[nit] Fix test failure due to perl6's behaviour about lexical `use`

### DIFF
--- a/t/Crust-Builder/mount.t
+++ b/t/Crust-Builder/mount.t
@@ -2,6 +2,7 @@ use v6;
 use Test;
 use Crust::Builder;
 use Crust::Test;
+use HTTP::Request;
 
 subtest {
     my $app = sub ($env) {

--- a/t/Crust-Middleware/auth_basic.t
+++ b/t/Crust-Middleware/auth_basic.t
@@ -2,6 +2,7 @@ use v6;
 use Test;
 use Crust::Builder;
 use Crust::Test;
+use HTTP::Request;
 
 my %map = (
     :admin("s3cr3t"),


### PR DESCRIPTION
I found Crust's some tests fail on my environment.
It's maybe due to recent MoarVM's behavior about lexical `use` has changed.
So I added necessary `use` to those tests.

```
[github.com/astj/p6-Crust]$ perl6 -version
This is Rakudo version 2016.12-108-g005166eed built on MoarVM version 2016.12-6-g65acd555
implementing Perl 6.c.
```

```
[github.com/astj/p6-Crust]$ prove --exec 'perl6 -Ilib -It/lib' -vr t/Crust-Builder/mount.t t/Crust-Middleware/auth_basic.t
t/Crust-Builder/mount.t .......... Could not find symbol '&Request'
  in block  at t/Crust-Builder/mount.t line 31
  in sub subtest at /Users/astj/.rakudobrew/moar-nom/install/share/perl6/sources/C712FE6969F786C9380D643DF17E85D06868219E (Test) line 364
  in block <unit> at t/Crust-Builder/mount.t line 6

Actually thrown at:
  in block  at t/Crust-Builder/mount.t line 31
  in sub subtest at /Users/astj/.rakudobrew/moar-nom/install/share/perl6/sources/C712FE6969F786C9380D643DF17E85D06868219E (Test) line 364
  in block <unit> at t/Crust-Builder/mount.t line 6

Dubious, test returned 1 (wstat 256, 0x100)
No subtests run
t/Crust-Middleware/auth_basic.t .. Could not find symbol '&Request'
  in block <unit> at t/Crust-Middleware/auth_basic.t line 24

Actually thrown at:
  in block <unit> at t/Crust-Middleware/auth_basic.t line 24

Dubious, test returned 1 (wstat 256, 0x100)
No subtests run

Test Summary Report
-------------------
t/Crust-Builder/mount.t        (Wstat: 256 Tests: 0 Failed: 0)
  Non-zero exit status: 1
  Parse errors: No plan found in TAP output
t/Crust-Middleware/auth_basic.t (Wstat: 256 Tests: 0 Failed: 0)
  Non-zero exit status: 1
  Parse errors: No plan found in TAP output
Files=2, Tests=0,  1 wallclock secs ( 0.02 usr  0.01 sys +  0.78 cusr  0.09 csys =  0.90 CPU)
Result: FAIL
```