### PR TITLE
Add workaround to make crustup work in Rakudo > 2016.11

### DIFF
--- a/lib/Crust/Runner.pm6
+++ b/lib/Crust/Runner.pm6
@@ -113,6 +113,7 @@ multi method run() {
 
     my $handler = "Crust::Handler::{$!server}";
     # FIXME: workaround for Bug RT #130535
+    # ref: https://github.com/tokuhirom/p6-Crust/pull/85
     EVAL "use $handler";
     my $httpd = ::($handler).new(|%!options);
     $httpd.run(&app);

--- a/lib/Crust/Runner.pm6
+++ b/lib/Crust/Runner.pm6
@@ -112,7 +112,8 @@ multi method run() {
     }
 
     my $handler = "Crust::Handler::{$!server}";
-    require ::($handler);
+    # FIXME: workaround for Bug RT #130535
+    EVAL "use $handler";
     my $httpd = ::($handler).new(|%!options);
     $httpd.run(&app);
 }


### PR DESCRIPTION
ref: https://rt.perl.org/Public/Bug/Display.html?id=130535

Currently we cannot run `crustup` in rakudo > 2016.11. I know this patch is ugly, but at least it works.