### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -2,6 +2,7 @@
   "name" : "Crust",
   "source-url" : "git://github.com/tokuhirom/p6-Crust.git",
   "perl" : "6",
+  "license" : "Artistic-2.0",
   "build-depends" : [ ],
   "provides" : {
     "Crust::Utils" : "lib/Crust/Utils.pm6",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license