### PR TITLE
Use IO::Handle.path.s instead of IO::Handle.s

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: perl6
 perl6:
   - latest
 install:
-  - rakudobrew build-panda
-  - panda --notests installdeps .
+  - rakudobrew build-zef
+  - zef install --/test --depsonly .
 script:
   - prove -vr -e 'perl6 -Ilib' t/
 sudo: false

--- a/lib/Crust/Utils.pm6
+++ b/lib/Crust/Utils.pm6
@@ -49,7 +49,7 @@ sub content-length($body) is export {
         }
         return $cl;
     } elsif $body.isa(IO::Handle) {
-        return $body.s - $body.tell;
+        return $body.path.s - $body.tell;
     }
 
     return Nil;


### PR DESCRIPTION
Ref: https://github.com/tokuhirom/p6-Crust/pull/89#issuecomment-297160507
As @zoffixznet says, replace `$handle.s` with `$handle.path.s`.

I discovered the last implementation of `IO::Handle.s` was actually redirection to `.path.s`. https://github.com/rakudo/rakudo/commit/36ad92a8b4a63de6a4fd6e9260d976c7632a46d0
