### PR TITLE
Change %env<p6w.errors> to Supplier in HTTP::Message::P6W

### DIFF
--- a/lib/HTTP/Message/P6W.pm6
+++ b/lib/HTTP/Message/P6W.pm6
@@ -7,6 +7,13 @@ use URI::Escape;
 use IO::Blob;
 use URI;
 
+sub supplier-for-io(IO::Handle $io --> Supplier) {
+    my $supplier = Supplier.new;
+    my $supply = $supplier.Supply;
+    $supply.tap(-> $v { $io.say($v) });
+    return $supplier;
+}
+
 our sub req-to-p6w($req, *%args) {
     my $uri = $req.uri;
     my IO::Blob $input .= new(
@@ -28,7 +35,7 @@ our sub req-to-p6w($req, *%args) {
         'p6w.version'      => Version.new("0.7.Draft"),
         'p6w.url-scheme'   => $uri.scheme eq 'https' ?? 'https' !! 'http',
         'p6w.input'        => $input,
-        'p6w.errors'       => $*ERR,
+        'p6w.errors'       => supplier-for-io($*ERR),
         'p6w.multithread'  => False,
         'p6w.multiprocess' => False,
         'p6w.run_once'     => True,

--- a/t/HTTP-Message-P6W/error.t
+++ b/t/HTTP-Message-P6W/error.t
@@ -1,0 +1,18 @@
+use v6;
+use Test;
+use HTTP::Message::P6W;
+use HTTP::Request;
+use IO::Blob;
+
+my $io = IO::Blob.new();
+$*ERR = $io;
+
+my $env = HTTP::Request.new(GET => "http://localhost/").to-p6w;
+isa-ok $env<p6w.errors>, Supplier;
+
+lives-ok { $env<p6w.errors>.emit('ohno'); }, 'can emit';
+
+$io.seek(0);
+is $io.slurp-rest, "ohno\n";
+
+done-testing;


### PR DESCRIPTION
ref: #94

`%env<p6w.errors>` has became Supplier, but HTTP::Message::P6W still uses raw `$*ERR`.

(Btw very similar code is present in HTTP::Server::Tiny : https://github.com/tokuhirom/p6-HTTP-Server-Tiny/pull/52/files#diff-c0a58c1c98f8c011a1987d2167aa590dR12. Is it useful if I ship it as an independent module? Or it's too small to ship?)