### PR TITLE
Something subtle has changed in .pairup, this fixes it

### DIFF
--- a/lib/Crust/Middleware/Lint.pm6
+++ b/lib/Crust/Middleware/Lint.pm6
@@ -64,10 +64,10 @@ my sub validate-ret(@ret) {
     my $copy = @ret[1];
 
     {
-        $copy.pairup();
+        $copy>>.pairup();
         CATCH {
             default {
-                die 'The number of response headers needs to be even, not odd(', $copy, ')';
+                die 'The number of response headers needs to be even, not odd(', $copy, ' )';
             }
         }
     }


### PR DESCRIPTION
Not quite sure what has changed in .pairup but it was getting

```
P6opaque: no such attribute '$!value' in type Pair when trying to get a value
  in block <unit> at -e line 1
```
when it encountered the pairs in the headers.  This papers over that for the time being.