### PR TITLE
Fixed test error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /blib/
-/lib/.precomp/
-/t/lib/.precomp/
+**/.precomp/

--- a/README.md
+++ b/README.md
@@ -110,6 +110,19 @@ AUTHORS
 
   * fayland
 
+INSTALL AND TEST
+================
+
+Install dependencies with 
+
+    zef install .
+	
+And then test with
+
+    prove -Ilib --exec "perl6 -Ilib" -r t
+	
+(provided `prove` is installed via Perl5's `Test::Harness`)
+
 COPYRIGHT AND LICENSE
 =====================
 

--- a/README.md
+++ b/README.md
@@ -115,13 +115,19 @@ INSTALL AND TEST
 
 Install dependencies with 
 
-    zef install .
+    zef install --deps-only .
 	
 And then test with
 
     prove -Ilib --exec "perl6 -Ilib" -r t
 	
 (provided `prove` is installed via Perl5's `Test::Harness`)
+
+Or better
+
+    zef test .
+	
+(this will use available test facilities, including the one above)
 
 COPYRIGHT AND LICENSE
 =====================

--- a/lib/Crust/Middleware/Lint.pm6
+++ b/lib/Crust/Middleware/Lint.pm6
@@ -60,11 +60,10 @@ my sub validate-ret(@ret) {
     unless @ret[1].isa(List) {
         die "Headers needs to be an list: @ret[1]";
     }
-
     my $copy = @ret[1];
-
     {
-        $copy.pairup();
+	our %this-copy = $copy;
+        %this-copy.pairup();
         CATCH {
             default {
                 die 'The number of response headers needs to be even, not odd(', $copy, ')';

--- a/t/Crust-Middleware/lint.t
+++ b/t/Crust-Middleware/lint.t
@@ -111,7 +111,7 @@ subtest {
             }
         );
         lives-ok({await $code(%env)});
-    }, 'Should works fine';
+    }, 'Should work fine';
 
     subtest {
         my $code = Crust::Middleware::Lint.new(
@@ -125,7 +125,7 @@ subtest {
             sub (%env) { start { 'status!!', [], ['hello'] } }
         );
         dies-ok({await $code(%env)});
-    }, 'Should die because response has not numerical status code';
+    }, 'Should die because response has not got a numerical status code';
 
     subtest {
         my $code = Crust::Middleware::Lint.new(


### PR DESCRIPTION
And adds a few instructions to test things locally.
This test failed with 2017.10 and 11 and it was just because it needs to be coerced into a hash before testing if it's in pairs or not. @zoffixznet 's Advent post helped here https://perl6advent.wordpress.com/2017/12/02/perl-6-sigils-variables-and-containers/