### PR TITLE
Use hash comparison to be order independent.

### DIFF
--- a/t/Crust-Middleware/error-document.t
+++ b/t/Crust-Middleware/error-document.t
@@ -77,7 +77,7 @@ subtest {
     my @ret = await $app(%env);
 
     is @ret[0], 500;
-    is-deeply @ret[1], ['p6wx.errordocument.Content-Type' => 'text/plain', :Content-Type('text/plain')];
+    is-deeply @ret[1].Hash, {'p6wx.errordocument.Content-Type' => 'text/plain', :Content-Type('text/plain')};
     isa-ok @ret[2], Array;
 }, 'Sub Request';
 


### PR DESCRIPTION
Hi,
this fixes the flappiness mentioned in https://github.com/perl6/ecosystem-unbitrot/issues/255