### PR TITLE
Don't test actual line number

### DIFF
--- a/t/Crust-Middleware/stack-trace.t
+++ b/t/Crust-Middleware/stack-trace.t
@@ -61,7 +61,7 @@ subtest {
     is $ret[2].elems, 1;
     like $ret[2][0], rx{'Error:' \s+ 'in block  at ' \S+ ' line ' \d+};
 
-    like %env<crust.stacktrace.text>, rx{'in sub  at t/Crust-Middleware/stack-trace.t line 51'};
+    like %env<crust.stacktrace.text>, rx{'in sub  at t/Crust-Middleware/stack-trace.t line ' \d+};
     like %env<crust.stacktrace.html>, rx{'Error:   in block  at ' \S+ ' line ' \d+};
 
     like $buf.result, rx{'in sub  at t/Crust-Middleware/stack-trace.t line ' \d+};


### PR DESCRIPTION
Different implementations may print slightly different line numbers
(in fact, the whole backtrace can be slightly different). Line numbers
were fixed between rakudo 2018.12 and 2019.01, this commit relaxes the
check slightly. Note that other tests are already not expecting exact
numbers.