### PR TITLE
Declare dependency on HTTP::Tinyish at test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ perl6:
   - latest
 install:
   - rakudobrew build-zef
-  - zef install --/test --depsonly .
+  - zef install --/test --test-depends --depsonly .
 script:
   - prove -vr -e 'perl6 -Ilib' t/
 sudo: false

--- a/META6.json
+++ b/META6.json
@@ -56,6 +56,8 @@
   "resources" : [ ],
   "source-url" : "git://github.com/tokuhirom/p6-Crust.git",
   "tags" : [ ],
-  "test-depends" : [ ],
+  "test-depends" : [
+    "HTTP::Tinyish"
+  ],
   "version" : "0.0.1"
 }


### PR DESCRIPTION
`HTTP::Tinyish` is used in tests, but the dependency is not declared in META6.json.

https://github.com/tokuhirom/p6-Crust/blob/fe89509964d5714c03374842325e2fb54808ed72/t/Crust-Handler/HTTP-Server-Tiny.t#L7

It looks like this module is used in tests only, so I added it as test-depends.

I believe all currently failing tests will be fixed with this patch and #107.