### PR TITLE
URI.new.path now returns URI::Path

### DIFF
--- a/lib/HTTP/Message/P6W.pm6
+++ b/lib/HTTP/Message/P6W.pm6
@@ -21,7 +21,7 @@ our sub req-to-p6w($req, *%args) {
     );
 
     my $env = {
-        PATH_INFO         => uri_unescape($uri.path || '/'),
+        PATH_INFO         => uri-unescape($uri.path.Str || '/'),
         QUERY_STRING      => $uri.query || '',
         SCRIPT_NAME       => '',
         SERVER_NAME       => $uri.host,


### PR DESCRIPTION
So you can't simply pass it to uri-encode without stringifying.